### PR TITLE
Add legacy token parameter

### DIFF
--- a/cmd/masl/masl.go
+++ b/cmd/masl/masl.go
@@ -21,11 +21,12 @@ var version, build string
 
 // CLIFlags represents the command line flags
 type CLIFlags struct {
-	Version bool
-	Profile string
-	Env     string
-	Account string
-	Role    string
+	Version     bool
+	LegacyToken bool
+	Profile     string
+	Env         string
+	Account     string
+	Role        string
 }
 
 func main() {
@@ -107,7 +108,7 @@ func main() {
 	role := selectRole(roles)
 
 	assertionOutput := masl.AssumeRole(samlData, int64(conf.Duration), role, logger)
-	masl.SetCredentials(assertionOutput, usr.HomeDir, flags.Profile, logger)
+	masl.SetCredentials(assertionOutput, usr.HomeDir, flags.Profile, flags.LegacyToken, logger)
 
 	logger.Info("w00t w00t masl for you!, Successfully authenticated.")
 
@@ -121,6 +122,7 @@ func parseFlags(conf masl.Config) CLIFlags {
 	flags := new(CLIFlags)
 
 	flag.BoolVar(&flags.Version, "version", false, "prints MASL version")
+	flag.BoolVar(&flags.LegacyToken, "legacy-token", false, "configures legacy aws_security_token (for Boto support)")
 	flag.StringVar(&flags.Profile, "profile", conf.Profile, "AWS profile name")
 	flag.StringVar(&flags.Env, "env", "", "Work environment")
 	flag.StringVar(&flags.Account, "account", "", "AWS Account ID or name")

--- a/internal/masl/saml.go
+++ b/internal/masl/saml.go
@@ -319,7 +319,7 @@ func AssumeRole(samlAssertion string, duration int64, role *SAMLAssertionRole,
 
 // SetCredentials Apply the STS credentials on the host
 func SetCredentials(assertionOutput *sts.AssumeRoleWithSAMLOutput, homeDir string,
-	profileName string, log *logrus.Logger) {
+	profileName string, legacyToken bool, log *logrus.Logger) {
 	filename := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
 	if filename == "" {
 		filename = homeDir + string(os.PathSeparator) + ".aws" +
@@ -342,6 +342,11 @@ func SetCredentials(assertionOutput *sts.AssumeRoleWithSAMLOutput, homeDir strin
 	sec.NewKey("aws_access_key_id", *assertionOutput.Credentials.AccessKeyId)
 	sec.NewKey("aws_secret_access_key", *assertionOutput.Credentials.SecretAccessKey)
 	sec.NewKey("aws_session_token", *assertionOutput.Credentials.SessionToken)
+	if legacyToken {
+		sec.NewKey("aws_security_token", *assertionOutput.Credentials.SessionToken)
+	} else {
+		sec.DeleteKey("aws_security_token")
+	}
 	err := cfg.SaveTo(filename)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
Old Boto library reads aws_security_token instead of
aws_session_token. The Ansible dynamic EC2 inventory for instance
uses Boto instead of Boto3 and doesn't work with Masl at the
moment.

This allows setting the -legacy-token param, which simply copies
the token into the aws_security_token key in the credentials
file.